### PR TITLE
[tarik] making hash code index aware

### DIFF
--- a/Tactical.DDD.Tests/ValueObjectTests.cs
+++ b/Tactical.DDD.Tests/ValueObjectTests.cs
@@ -53,5 +53,16 @@ namespace Tactical.DDD.Tests
             Assert.False(null == assignee);
             Assert.True(assignee != null);
         }
+
+        [Fact]
+        public void ValueObject_HashCodeValueShouldBeDependentOnIndex()
+        {
+            var assignee0 = new Assignee("sam", "sam");
+            var assignee1 = new Assignee("joe", "joe");
+            var assignee2 = new Assignee("sam", "sam");
+
+            Assert.True(assignee0 != assignee1);
+            Assert.False(assignee0 != assignee2);
+        }
     }
 }

--- a/Tactical.DDD/ValueObject.cs
+++ b/Tactical.DDD/ValueObject.cs
@@ -13,6 +13,7 @@ namespace Tactical.DDD
     {
         /// <summary>
         /// This is needed as salt for index. If only index was used, there is a chance that i ^ i+some_low_number produces same value
+        /// Issue is shown in following fiddle: https://dotnetfiddle.net/E3tgYY
         /// </summary>
         private const int HighPrime = 557927;
 

--- a/Tactical.DDD/ValueObject.cs
+++ b/Tactical.DDD/ValueObject.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -13,6 +12,11 @@ namespace Tactical.DDD
     public abstract class ValueObject
     {
         /// <summary>
+        /// This is needed as salt for index. If only index was used, there is a chance that i ^ i+some_low_number produces same value
+        /// </summary>
+        private const int HighPrime = 557927;
+
+        /// <summary>
         /// Override GetAtomicValues in order to implement structural equality for your value object.
         /// </summary>
         /// <returns>Enumerable of properties to participate in equality comparison</returns>
@@ -21,7 +25,7 @@ namespace Tactical.DDD
         public override int GetHashCode()
         {
             return GetAtomicValues()
-                .Select((x, i) => $"{x?.GetType().FullName}_{x?.GetHashCode() ?? 0}_{Math.Pow(2, i)}".GetHashCode())
+                .Select((x, i) => (x != null ? x.GetHashCode() : 0) + (HighPrime * i))
                 .Aggregate((x, y) => x ^ y);
         }
 

--- a/Tactical.DDD/ValueObject.cs
+++ b/Tactical.DDD/ValueObject.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -20,7 +21,7 @@ namespace Tactical.DDD
         public override int GetHashCode()
         {
             return GetAtomicValues()
-                .Select(x => x != null ? x.GetHashCode() : 0)
+                .Select((x, i) => $"{x?.GetType().FullName}_{x?.GetHashCode() ?? 0}_{Math.Pow(2, i)}".GetHashCode())
                 .Aggregate((x, y) => x ^ y);
         }
 


### PR DESCRIPTION
Issue was that folllowing 2 objects would always produce hash code of 0 due usage of xor to combine atomic value hash codes.
```
var assignee0 = new Assignee("sam", "sam");
var assignee1 = new Assignee("joe", "joe");
```
I have made it so that hash code of atomic value is aware of it's index (by adding multiplicative `index*highPrimeNumber` as salt. Following [fiddle](https://dotnetfiddle.net/E3tgYY) shows the issue with low difference between 2 hashes and xor.
Now it should be unique for 99.99% of the cases due it's index awarness. Better solution would be to compare value by value while itterating over atomic values from both sides (something like `lhs.Current == rhs.Current`).